### PR TITLE
Add more structure to dispensaries

### DIFF
--- a/pages/dispensaries/index.js
+++ b/pages/dispensaries/index.js
@@ -10,18 +10,50 @@ export default function Dispensaries() {
   const { stores, currentPage, pageCount } = data;
 
   return (
-    <div>
-      {stores.map((store) => (
-        <div>
-          {/*
-            {store.coverImage}
-            {store.name}
-            {store.hasPickupEnabled}
-            {store.distanceToUser}
-            {store.tagline}
-          */}
-        </div>
-      ))}
-    </div>
+    <>
+      <div className="store-list">
+        {stores.map((store) => (
+          <div className="store">
+            <h2 className="store__name">{store.name}</h2>
+            <div className="store__pickup">Pickup Enabled</div>
+            <div className="store__tagline">{store.tagline}</div>
+          </div>
+        ))}
+      </div>
+
+      <style jsx>
+        {`
+          .store-list {
+            background-color: lightgray;
+            padding: 20px;
+          }
+
+          .store {
+            background-color: white;
+            border-radius: 4px;
+            font-size: 14px;
+            line-height: 1.4;
+            margin-bottom: 16px;
+            padding: 16px;
+            width: 400px;
+          }
+
+          .store__name {
+            color: forestgreen;
+            font-size: 20px;
+            margin: 0;
+          }
+
+          .store__pickup {
+            color: tomato;
+          }
+
+          .store__tagline {
+            color: slategray;
+            margin-top: 10px;
+          }
+        `}
+      </style>
+    </>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,10 @@ body {
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }
 
+body {
+  margin: 0;
+}
+
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
This change adds both more HTML structure and CSS to get the styling of dispensaries most of the way there. The thrust of this change is to get the candidate to the bonus questions of the exercise that involve managing state, in lieu of spending most of the time fiddling with HTML/CSS.

The idea here is to focus on two HTML/CSS updates: adding the `coverImage` (looking at CSS layout skills) and adding `distanceToUser` (inserting a moment to suggest using `toFixed` when the candidate gets stuck on float precision; most candidates don't know this method off the top of their head).

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/46891/122262121-ec959700-ce89-11eb-8b3d-859709483418.png">

A few open questions:
* I used styled-jsx here, but could also use either CSS modules or put everything in global.css
* I've used BEM-style CSS classes, but this might be too complex; should these be walked back to more generic class names?